### PR TITLE
ask 01: Scaffold Next.js pages

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -7,8 +7,15 @@
     "start": "next start",
     "test": "jest"
   },
-  "dependencies": {},
+  "dependencies": {
+    "next": "13.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
   "devDependencies": {
-    "jest": "^29.0.0"
+    "jest": "^29.0.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
   }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/pages/card/[slug].tsx
+++ b/pages/card/[slug].tsx
@@ -1,0 +1,27 @@
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+
+interface Props {
+  slug: string;
+}
+
+export default function CardPage({ slug }: Props) {
+  return (
+    <>
+      <Head>
+        <title>Card {slug}</title>
+      </Head>
+      <div className="min-h-screen flex items-center justify-center font-serif">
+        <div className="text-center p-8 border rounded shadow">
+          <h1 className="text-2xl mb-4">Card: {slug}</h1>
+          <p>This is a server rendered card page.</p>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { slug } = context.params as { slug: string };
+  return { props: { slug } };
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,17 @@
+import Head from 'next/head';
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>Echoes of Dawn</title>
+      </Head>
+      <div className="min-h-screen flex items-center justify-center font-sans">
+        <Link href="/card/demo" className="bg-blue-500 hover:bg-blue-600 text-white py-2 px-4 rounded">
+          Draw Demo Card
+        </Link>
+      </div>
+    </>
+  );
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond&family=Noto+Sans+JP:wght@400;700&display=swap');
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html {
+  font-family: 'Noto Sans JP', sans-serif;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        serif: ['\'EB Garamond\'', 'serif'],
+        sans: ['\'Noto Sans JP\'', 'sans-serif']
+      }
+    }
+  },
+  plugins: []
+};

--- a/tests/dummy.test.js
+++ b/tests/dummy.test.js
@@ -1,0 +1,3 @@
+it('dummy test', () => {
+  expect(true).toBe(true);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js with basic TypeScript setup
- add Tailwind and load EB Garamond + Noto Sans JP fonts
- create index page with **Draw Demo Card** CTA
- add dynamic card page using server-side props
- configure Jest and add a passing dummy test

## Testing
- `npm test` *(fails: jest not found)*