### PR TITLE
Add demo-draw API endpoint

### DIFF
--- a/__tests__/demo-draw.test.js
+++ b/__tests__/demo-draw.test.js
@@ -1,0 +1,26 @@
+import handler from '../pages/api/demo-draw'
+
+describe('GET /api/demo-draw', () => {
+  const env = process.env
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { SUPABASE_URL: 'http://localhost', SUPABASE_ANON_KEY: 'anon' }
+  })
+
+  afterEach(() => {
+    process.env = env
+    jest.restoreAllMocks()
+  })
+
+  it('returns a card', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ image_url: 'img', mantra: 'm', question: 'q' }],
+    })
+    const req = {}
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() }
+    await handler(req, res)
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({ image_url: 'img', mantra: 'm', question: 'q' })
+  })
+})

--- a/pages/api/demo-draw.js
+++ b/pages/api/demo-draw.js
@@ -1,0 +1,30 @@
+
+export default async function handler(req, res) {
+  const { SUPABASE_URL, SUPABASE_ANON_KEY } = process.env;
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    res.status(500).json({ error: 'Missing Supabase env vars' });
+    return;
+  }
+
+  try {
+    const url = `${SUPABASE_URL}/rest/v1/demo_cards?select=image_url,mantra,question&limit=1&order=random`;
+    const response = await fetch(url, {
+      headers: {
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      res.status(response.status).json({ error: text });
+      return;
+    }
+
+    const data = await response.json();
+    const card = data[0] || null;
+    res.status(200).json(card);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}


### PR DESCRIPTION
## Summary
- implement `/api/demo-draw` endpoint to fetch a random card from Supabase
- add Jest test covering the endpoint

## Testing
- `npm test` *(fails: jest not found)*