### PR TITLE
Add screenshot download endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ Key feature: draw a demo reflection card → download / email → save to Notion
 
 Tech stack: Next.js, Supabase, Mailchimp, Notion API.
 
+## Screenshot API
+
+An Edge Function using `@vercel/og` is available at `/api/screenshot`. Pass a `title` query
+parameter to customize text. The response is a downloadable image named
+`screenshot.png`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "start": "next start",
     "test": "jest"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@vercel/og": "^0.6.0"
+  },
   "devDependencies": {
     "jest": "^29.0.0"
   }

--- a/pages/api/screenshot.ts
+++ b/pages/api/screenshot.ts
@@ -1,0 +1,39 @@
+import { ImageResponse } from '@vercel/og';
+
+export const config = {
+  runtime: 'edge',
+};
+
+export default async function handler(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const title = searchParams.get('title') || 'Echoes of Dawn';
+
+  const image = new ImageResponse(
+    (
+      <div
+        style={{
+          fontSize: 72,
+          background: 'white',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {title}
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    }
+  );
+
+  return new Response(image.body!, {
+    headers: {
+      'Content-Type': 'image/png',
+      'Content-Disposition': 'attachment; filename="screenshot.png"',
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- create `/api/screenshot` Edge function using `@vercel/og`
- document the endpoint
- add `@vercel/og` as a dependency

## Testing
- `npm test` *(fails: jest not found)*