### PR TITLE
Add save-email API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ Key feature: draw a demo reflection card → download / email → save to Notion
 
 Tech stack: Next.js, Supabase, Mailchimp, Notion API.
 
+## API
+
+### POST `/api/save-email`
+Store an email address in Supabase and subscribe the address to the configured Mailchimp audience. Provide JSON `{ "email": "user@example.com" }` in the request body.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "start": "next start",
     "test": "jest"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@supabase/supabase-js": "^2.0.0",
+    "@mailchimp/mailchimp_marketing": "^5.0.0"
+  },
   "devDependencies": {
     "jest": "^29.0.0"
   }

--- a/pages/api/save-email.js
+++ b/pages/api/save-email.js
@@ -1,0 +1,45 @@
+import { createClient } from '@supabase/supabase-js';
+import mailchimp from '@mailchimp/mailchimp_marketing';
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_ANON_KEY;
+const mailchimpApiKey = process.env.MAILCHIMP_API_KEY;
+const mailchimpAudienceId = process.env.MAILCHIMP_AUDIENCE_ID;
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+if (mailchimpApiKey) {
+  mailchimp.setConfig({
+    apiKey: mailchimpApiKey,
+    server: mailchimpApiKey.split('-')[1],
+  });
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { email } = req.body || {};
+  if (!email) {
+    return res.status(400).json({ error: 'Email required' });
+  }
+
+  try {
+    if (supabaseUrl && supabaseKey) {
+      await supabase.from('emails').insert({ email });
+    }
+
+    if (mailchimpApiKey && mailchimpAudienceId) {
+      await mailchimp.lists.addListMember(mailchimpAudienceId, {
+        email_address: email,
+        status: 'subscribed',
+      });
+    }
+
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}


### PR DESCRIPTION
## Summary
- implement `/api/save-email` endpoint
- document email API in README
- add supabase and mailchimp libs to package.json

## Testing
- `npm test` *(fails: jest not found)*