### PR TITLE
Implement Notion OAuth handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "start": "next start",
     "test": "jest"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@notionhq/client": "^2.2.3"
+  },
   "devDependencies": {
     "jest": "^29.0.0"
   }

--- a/pages/api/notion-auth.js
+++ b/pages/api/notion-auth.js
@@ -1,0 +1,25 @@
+export default async function handler(req, res) {
+  const { code, redirect_uri } = req.query;
+  if (!code) {
+    return res.status(400).json({ error: 'Missing code' });
+  }
+  try {
+    const response = await fetch('https://api.notion.com/v1/oauth/token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Basic ${Buffer.from(`${process.env.NOTION_CLIENT_ID}:${process.env.NOTION_CLIENT_SECRET}`).toString('base64')}`
+      },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri
+      })
+    });
+    const data = await response.json();
+    // TODO: persist access token for user
+    return res.status(200).json(data);
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+}

--- a/pages/api/notion-save-card.js
+++ b/pages/api/notion-save-card.js
@@ -1,0 +1,34 @@
+import { Client } from '@notionhq/client';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+  const { token, pageId, card } = req.body;
+  if (!token || !pageId || !card) {
+    return res.status(400).json({ error: 'Missing parameters' });
+  }
+  const notion = new Client({ auth: token });
+  try {
+    await notion.blocks.children.append({
+      block_id: pageId,
+      children: [
+        {
+          object: 'block',
+          type: 'paragraph',
+          paragraph: {
+            rich_text: [
+              {
+                type: 'text',
+                text: { content: card }
+              }
+            ]
+          }
+        }
+      ]
+    });
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/notion-auth` API route to exchange OAuth code for tokens
- add `/api/notion-save-card` API route to append a card to a Notion page
- include `@notionhq/client` dependency

## Testing
- `npm test` *(fails: jest not found)*