### PR TITLE
Add coming soon email capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ Key feature: draw a demo reflection card → download / email → save to Notion
 
 Tech stack: Next.js, Supabase, Mailchimp, Notion API.
 
+## Early Access
+
+Visit `/coming-soon` to sign up for early access. Emails are saved to Supabase and tagged in Mailchimp via the `/api/save-email` route.
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,13 @@
     "start": "next start",
     "test": "jest"
   },
-  "dependencies": {},
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "^2.0.0",
+    "@mailchimp/mailchimp_marketing": "^3.0.0"
+  },
   "devDependencies": {
     "jest": "^29.0.0"
   }

--- a/pages/api/save-email.js
+++ b/pages/api/save-email.js
@@ -1,0 +1,37 @@
+import { createClient } from '@supabase/supabase-js';
+import mailchimp from '@mailchimp/mailchimp_marketing';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_ANON_KEY
+);
+
+mailchimp.setConfig({
+  apiKey: process.env.MAILCHIMP_API_KEY,
+  server: process.env.MAILCHIMP_API_KEY?.split('-')[1],
+});
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { email } = req.body;
+  if (!email) {
+    res.status(400).json({ error: 'Email required' });
+    return;
+  }
+
+  try {
+    await supabase.from('early_access_emails').insert({ email });
+    await mailchimp.lists.addListMember(process.env.MAILCHIMP_AUDIENCE_ID, {
+      email_address: email,
+      status: 'subscribed',
+    });
+    res.status(200).json({ message: 'saved' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save email' });
+  }
+}

--- a/pages/coming-soon.js
+++ b/pages/coming-soon.js
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+
+export default function ComingSoon() {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState('');
+
+  async function submit(e) {
+    e.preventDefault();
+    setStatus('Submitting...');
+    try {
+      const res = await fetch('/api/save-email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      });
+      if (res.ok) {
+        setStatus('Thanks for signing up!');
+        setEmail('');
+      } else {
+        setStatus('Something went wrong.');
+      }
+    } catch (err) {
+      setStatus('Error submitting.');
+    }
+  }
+
+  return (
+    <div style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+      <h1>Echoes of Dawn</h1>
+      <h2>Coming Soon</h2>
+      <p>Sign up below for early access.</p>
+      <form onSubmit={submit}>
+        <input
+          type="email"
+          placeholder="you@example.com"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          required
+        />
+        <button type="submit">Notify Me</button>
+      </form>
+      {status && <p>{status}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add dependencies for Next.js, Supabase and Mailchimp
- document early access instructions
- create `/coming-soon` page with email signup form
- add `/api/save-email` route to store and tag emails

## Testing
- `npm test` *(fails: jest not found)*